### PR TITLE
feat(default-credential): init storage with default env credential

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roit/roit-storage",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "types": "src/index.ts",
   "repository": "github:roitinnovation/roit-storage",

--- a/src/google-cloud-storage/GoogleCloudConfig.ts
+++ b/src/google-cloud-storage/GoogleCloudConfig.ts
@@ -4,18 +4,20 @@ import { CredentialBody } from 'google-auth-library'
 
 export class GoogleCloudConfig implements CloudConfig {
 
-    private readonly credentials: CredentialBody
+    private readonly credentials: CredentialBody | undefined
 
     constructor() {
         const credentialFile = Environment.getProperty('googleStorageCredential')
-        this.credentials = require(credentialFile)
+        if(credentialFile) {
+            this.credentials = require(credentialFile)
+        }
     }
 
     getConfig(): GoogleCloudConfig {
         return this
     }
 
-    getCredentials(): CredentialBody {
+    getCredentials(): CredentialBody | undefined {
         return this.credentials
     }
 }

--- a/src/google-cloud-storage/GoogleCloudHandler.ts
+++ b/src/google-cloud-storage/GoogleCloudHandler.ts
@@ -8,9 +8,15 @@ export class GoogleCloudHandler implements CloudHandler {
     private readonly storage: Storage
 
     constructor() {
-        this.storage = new Storage({
-            credentials: this.gcloudConfig.getCredentials()
-        })
+        const credentials = this.gcloudConfig.getCredentials()
+        
+        if(credentials) {
+            this.storage = new Storage({
+                credentials
+            })
+        } else {
+            this.storage = new Storage()
+        }
     }
 
     getInstance(): GoogleCloudHandler {


### PR DESCRIPTION
Permitir a criação do objeto do storage com as credenciais default do ambiente 